### PR TITLE
Add fallback for fetching external ip (ipinfo.io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,16 @@ It takes about 10 minutes to run, depending on your server setup. After you have
 **IMPORTANT: NOTE THE NEW SSH PORT AND MAKE SURE YOU CAN SSH INTO YOUR SERVER BEFORE CLOSING THE EXISTING SESSION**
 
 
-It has been tested with clean installs of: 
+Current release has been tested with clean installs of: 
 
-	Ubuntu 12 (old release)
-	Ubuntu 13 (old release)
-	Ubuntu 14 (old release)
-	Ubuntu 15 (old release)
 	Ubuntu 16
 	Ubuntu 17
 	Ubuntu 18
 	Ubuntu 19
-	Debian 7 "Wheezy" (old release)
-	Debian 8 "Jessie" (old release)
 	Debian 9 "Stretch"
 	Debian 10 "Buster"
+
+Older systems no longer supported, but works with 
 
 Services that will be installed and configured are
 
@@ -52,7 +48,13 @@ Services that will be installed and configured are
 
 [Additional information on all the features](https://github.com/arakasi72/rtinst/wiki/Guide)
 
-For older unssuported OS listed above see the [Older OS Installation Guide](https://github.com/arakasi72/rtinst/wiki/Installing-on-Older-OS)
+For older unssuported OS [Older OS Installation Guide](https://github.com/arakasi72/rtinst/wiki/Installing-on-Older-OS). These include:
+	Ubuntu 12 (old release)
+	Ubuntu 13 (old release)
+	Ubuntu 14 (old release)
+	Ubuntu 15 (old release)
+	Debian 7 "Wheezy" (old release)
+	Debian 8 "Jessie" (old release)
 
 To see latest updates to the script go to [Change Log](https://github.com/arakasi72/rtinst/wiki/Change-Log)
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Services that will be installed and configured are
 [Additional information on all the features](https://github.com/arakasi72/rtinst/wiki/Guide)
 
 For older unssuported OS [Older OS Installation Guide](https://github.com/arakasi72/rtinst/wiki/Installing-on-Older-OS). These include:
+	
 	Ubuntu 12 (old release)
 	Ubuntu 13 (old release)
 	Ubuntu 14 (old release)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Current release has been tested with clean installs of:
 	Debian 9 "Stretch"
 	Debian 10 "Buster"
 
-Older systems no longer supported, but works with 
-
 Services that will be installed and configured are
 
 	1. vsftpd - ftp server

--- a/rtsetup
+++ b/rtsetup
@@ -35,12 +35,7 @@ fi
 if [[ $(systemctl list-units --all apt-daily.service | fgrep -c apt-daily.service) -gt 0 ]]; then
   systemctl stop apt-daily.service > /dev/null 2>&1
   systemctl kill --kill-who=all apt-daily.service > /dev/null 2>&1
-
-# wait until `apt-get updated` has been killed
-  while ! (systemctl list-units --all apt-daily.service | fgrep -q dead)
-    do
-      sleep 1;
-    done
+  sleep 5
 fi
 
 apt-get -qq update

--- a/scripts/rtadduser
+++ b/scripts/rtadduser
@@ -353,7 +353,7 @@ echo "?>" >> /var/www/rutorrent/conf/users/$user/config.php
 mkdir /var/www/rutorrent/conf/users/$user/plugins/autodl-irssi
 mkdir -p $home/.irssi/scripts/autorun
 cd $home/.irssi/scripts
-curl -sL http://git.io/vlcND | grep -Po '(?<="browser_download_url": ")(.*-v[\d.]+.zip)' | xargs wget --quiet -O autodl-irssi.zip
+curl -sL http://git.io/vlcND | sed -n 's/.*browser_download_url": \?"\(.*zip\)".*/\1/p' | xargs wget --quiet -O autodl-irssi.zip
 unzip -o autodl-irssi.zip >> /dev/null 2>&1
 rm autodl-irssi.zip
 cp autodl-irssi.pl autorun/

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -35,6 +35,17 @@ fullrel=$(lsb_release -sd)
 osname=$(lsb_release -si)
 relno=$(lsb_release -sr | cut -d. -f1)
 
+# Fallback if lsb_release -si returns nothing
+if [ "$osname" = "" ]; then
+  osname=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+  osname=${osname^}
+fi
+
+# Fallback if lsb_release -sr returns nothing
+if [ "$relno" = "" ]; then
+  relno=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+fi
+
 if [ "$relno" = "16" ] || [ "$relno" = "17" ] || [ "$relno" = "9" ]; then
   phpver=php7.0
   phploc=/etc/php/7.0
@@ -544,6 +555,11 @@ for package_name in $package_list
       echo $package_name" not found, skipping"
     fi
   done
+
+# Installs a package needed to prevent arm64 architectures from "WARNING: Unable to start rtorrent"
+if [ "$(uname --m)" == "aarch64" ] || [ "$(dpkg --print-architecture)" == "arm64" ] ; then
+    sudo apt-get install libxmlrpc-core-c3-dev
+fi
 
 test -z "$install_list" || apt-get -qq install $install_list >> $logfile 2>&1
 if ! [ $? = 0 ]; then

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -8,110 +8,6 @@
 #
 #########################################################################################
 
-###############################
-### SET VARIABLES ###
-###############################
-
-PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
-
-# if left blank will install latest version of rtorrent, or set to a specific release E.G. '0.9.6' to install that release
-rtorrentrel='0.9.6'
-
-#url's of the major components
-rt_url="http://rtorrent.net/downloads/"
-
-xmlrpc_url="https://svn.code.sf.net/p/xmlrpc-c/code/advanced/"
-xmlrpc_url_alt="https://github.com/mirror/xmlrpc-c"
-
-ru_url="https://github.com/Novik/ruTorrent/"
-adl_url="https://github.com/autodl-community/"
-
-if [ $(dpkg-query -W -f='${Status}' lsb-release 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
-echo "Installing lsb-release"
-apt-get -yqq install lsb-release 2>&1 >> /dev/null
-fi
-
-fullrel=$(lsb_release -sd)
-osname=$(lsb_release -si)
-relno=$(lsb_release -sr | cut -d. -f1)
-
-# Fallback if lsb_release -si returns nothing
-if [ "$osname" = "" ]; then
-  osname=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
-  osname=${osname^}
-fi
-
-# Fallback if lsb_release -sr returns nothing
-if [ "$relno" = "" ]; then
-  relno=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
-fi
-
-if [ "$relno" = "16" ] || [ "$relno" = "17" ] || [ "$relno" = "9" ]; then
-  phpver=php7.0
-  phploc=/etc/php/7.0
-  libcver=libcurl3
-fi
-
-if [ "$(lsb_release -sr)" = "17.10" ]; then
-  phpver=php7.1
-  phploc=/etc/php/7.1
-  libcver=libcurl3
-fi
-
-if [ "$relno" = "18" ] || [ "$relno" = "19" ]; then
-  phpver=php7.2
-  phploc=/etc/php/7.2
-  libcver=libcurl4
-fi
-
-if [ "$relno" = "10" ]; then
-  phpver=php7.3
-  phploc=/etc/php/7.3
-  libcver=libcurl4
-fi
-
-serveripa=$(ip route get 8.8.8.8 | awk 'NR==1 {print $7}')
-serveripb=$(wget -qO- ipecho.net/plain)
-
-if [ "$serveripa" = "$serveripb" ]; then
-  serverip=$serveripa
-else
-  echo "Select the IP address to use:"
-  echo "1.) "$serveripa
-  echo "2.) "$serveripb
-
-  while true
-    do
-      read answer
-      case $answer in [1] ) serverip=$serveripa && break ;;
-                      [2] ) serverip=$serveripb && break ;;
-                        * ) echo "Enter 1 or 2";;
-    esac
-  done
-fi
-
-echo "IP set to "$serverip
-
-
-export logfile="/dev/null"
-webpass=''
-cronline1="@reboot sleep 10; /usr/local/bin/rtcheck irssi rtorrent"
-cronline2="*/10 * * * * /usr/local/bin/rtcheck irssi rtorrent"
-dlflag=1
-portdefault=1
-
-skip_rt=1
-sshport=''
-rudevflag=1
-rurelease=master
-passfile='/etc/nginx/.htpasswd'
-package_list="sudo nano autoconf build-essential ca-certificates comerr-dev curl dtach htop irssi libcppunit-dev $libcver libncurses5-dev libterm-readline-gnu-perl libsigc++-2.0-dev libperl-dev libtool libxml2-dev ncurses-base ncurses-term ntp patch pkg-config $phpver-fpm $phpver $phpver-cli $phpver-dev $phpver-curl php-geoip $phpver-xmlrpc $phpver-xml python-scgi screen subversion texinfo unzip zlib1g-dev libcurl4-openssl-dev mediainfo software-properties-common aptitude $phpver-json nginx-full apache2-utils git libarchive-zip-perl libnet-ssleay-perl libhtml-parser-perl libxml-libxml-perl libjson-perl libjson-xs-perl libxml-libxslt-perl libjson-rpc-perl libarchive-zip-perl"
-Install_list=""
-unixpass=""
-passflag=0
-forceyes=1
-selfsign=1
-rut_add_users=1
 
 ###############################
 ### FUNCTIONS ###
@@ -254,21 +150,137 @@ while true
 
 # function to enter IP address
 enter_ip() {
+local ip_address=$1
+
+exec 3>&1 >/dev/tty
+
 while true
   do
-    if valid_ip $serverip ; then
-      echo "Your Server IP is $serverip"
+    if valid_ip $ip_address ; then
+      echo "Your Server IP is $ip_address"
       echo -n "Is this correct y/n? "
-      ask_user && return 0
+      ask_user && break
     else
       echo "Invalid IP address, please try again"
     fi
 
     echo "enter your server's IP address"
     echo "e.g. 213.0.113.113"
-    read serverip
+    read ip_address
   done
+
+exec >&3-
+
+echo $ip_address
 }
+
+
+###############################
+### SET VARIABLES ###
+###############################
+
+PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
+
+# if left blank will install latest version of rtorrent, or set to a specific release E.G. '0.9.6' to install that release
+rtorrentrel='0.9.6'
+
+#url's of the major components
+rt_url="http://rtorrent.net/downloads/"
+
+xmlrpc_url="https://svn.code.sf.net/p/xmlrpc-c/code/advanced/"
+xmlrpc_url_alt="https://github.com/mirror/xmlrpc-c"
+
+ru_url="https://github.com/Novik/ruTorrent/"
+adl_url="https://github.com/autodl-community/"
+
+if [ $(dpkg-query -W -f='${Status}' lsb-release 2>/dev/null | grep -c "ok installed") -eq 0 ]; then
+echo "Installing lsb-release"
+apt-get -yqq install lsb-release 2>&1 >> /dev/null
+fi
+
+fullrel=$(lsb_release -sd)
+osname=$(lsb_release -si)
+relno=$(lsb_release -sr | cut -d. -f1)
+
+# Fallback if lsb_release -si returns nothing
+if [ "$osname" = "" ]; then
+  osname=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+  osname=${osname^}
+fi
+
+# Fallback if lsb_release -sr returns nothing
+if [ "$relno" = "" ]; then
+  relno=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+fi
+
+if [ "$relno" = "16" ] || [ "$relno" = "17" ] || [ "$relno" = "9" ]; then
+  phpver=php7.0
+  phploc=/etc/php/7.0
+  libcver=libcurl3
+fi
+
+if [ "$(lsb_release -sr)" = "17.10" ]; then
+  phpver=php7.1
+  phploc=/etc/php/7.1
+  libcver=libcurl3
+fi
+
+if [ "$relno" = "18" ] || [ "$relno" = "19" ]; then
+  phpver=php7.2
+  phploc=/etc/php/7.2
+  libcver=libcurl4
+fi
+
+if [ "$relno" = "10" ]; then
+  phpver=php7.3
+  phploc=/etc/php/7.3
+  libcver=libcurl4
+fi
+
+serveripa=$(ip route get 8.8.8.8 | awk 'NR==1 {print $7}')
+serveripb=$(wget -qO- ipecho.net/plain)
+
+if [ "$serveripa" = "$serveripb" ]; then
+  serverip=$serveripa
+else
+  echo "Select the IP address to use:"
+  echo "1.) "$serveripa
+  echo "2.) "$serveripb
+
+  while true
+    do
+      read answer
+      case $answer in [1] ) serverip=$serveripa && break ;;
+                      [2] ) serverip=$serveripb && break ;;
+                        * ) echo "Enter 1 or 2";;
+    esac
+  done
+fi
+
+echo "IP set to "$serverip
+
+
+export logfile="/dev/null"
+webpass=''
+cronline1="@reboot sleep 10; /usr/local/bin/rtcheck irssi rtorrent"
+cronline2="*/10 * * * * /usr/local/bin/rtcheck irssi rtorrent"
+dlflag=1
+portdefault=1
+
+skip_rt=1
+sshport=''
+rudevflag=1
+rurelease=master
+passfile='/etc/nginx/.htpasswd'
+package_list="sudo nano autoconf build-essential ca-certificates comerr-dev curl dtach htop irssi libcppunit-dev $libcver libncurses5-dev libterm-readline-gnu-perl libsigc++-2.0-dev libperl-dev libtool libxml2-dev ncurses-base ncurses-term ntp patch pkg-config $phpver-fpm $phpver $phpver-cli $phpver-dev $phpver-curl php-geoip $phpver-xmlrpc $phpver-xml python-scgi screen subversion texinfo unzip zlib1g-dev libcurl4-openssl-dev mediainfo software-properties-common aptitude $phpver-json nginx-full apache2-utils git libarchive-zip-perl libnet-ssleay-perl libhtml-parser-perl libxml-libxml-perl libjson-perl libjson-xs-perl libxml-libxslt-perl libjson-rpc-perl libarchive-zip-perl"
+Install_list=""
+unixpass=""
+passflag=0
+forceyes=1
+selfsign=1
+rut_add_users=1
+
+
 
 ###############################
 ### INITIAL SYSTEM CHECKS ###
@@ -359,7 +371,7 @@ fi
 echo
 
 # check IP Address
-[ $forceyes = 1 ] && enter_ip
+[ $forceyes = 1 ] && serverip=$(enter_ip $serverip)
 
 echo "Your server's IP is set to $serverip"
 export serverip

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -545,6 +545,7 @@ apt-get clean && apt-get autoclean >> $logfile 2>&1
 
 #install the packsges needed
 echo "Installing required packages" | tee -a $logfile
+apt-get install libtool -y >> $logfile 2>&1
 for package_name in $package_list
   do
     if [ $(apt-cache show -q=0 $package_name 2>&1 | grep -c "No packages found") -eq 0 ]; then
@@ -558,7 +559,7 @@ for package_name in $package_list
 
 # Installs a package needed to prevent arm64 architectures from "WARNING: Unable to start rtorrent"
 if [ "$(uname --m)" == "aarch64" ] || [ "$(dpkg --print-architecture)" == "arm64" ] ; then
-    sudo apt-get install libxmlrpc-core-c3-dev -y
+    sudo apt-get install libxmlrpc-core-c3-dev -y >> $logfile 2>&1
 fi
 
 test -z "$install_list" || apt-get -qq install $install_list >> $logfile 2>&1

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -165,11 +165,12 @@ tr -dc A-Za-z0-9 < /dev/urandom | head -c ${genln} | xargs
 
 #function executed if the script finishes early
 early_exit() {
+local rt_ee_version
 echo "Installation is incomplete. Run rtinst again to complete"
 echo
 if hash rtorrent >> /dev/null 2>&1; then
-  rt_current=$(rtorrent -h | grep -om 1 "[0-9]\{1,2\}\.[0-9]\{1,2\}\.[0-9]\{1,2\}")
-  echo "rtorrent $rt_current installed"
+  rt_ee_version=$(rtorrent -h | grep -om 1 "[0-9]\{1,2\}\.[0-9]\{1,2\}\.[0-9]\{1,2\}")
+  echo "rtorrent $rt_ee_version installed"
 else
   echo "rtorrent was not installed"
 fi

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -269,7 +269,7 @@ portdefault=1
 
 skip_rt=1
 sshport=''
-rudevflag=0
+rudevflag=1
 rurelease=master
 passfile='/etc/nginx/.htpasswd'
 package_list="sudo nano autoconf build-essential ca-certificates comerr-dev curl dtach htop irssi libcppunit-dev $libcver libncurses5-dev libterm-readline-gnu-perl libsigc++-2.0-dev libperl-dev libtool libxml2-dev ncurses-base ncurses-term ntp patch pkg-config $phpver-fpm $phpver $phpver-cli $phpver-dev $phpver-curl php-geoip $phpver-xmlrpc $phpver-xml python-scgi screen subversion texinfo unzip zlib1g-dev libcurl4-openssl-dev mediainfo software-properties-common aptitude $phpver-json nginx-full apache2-utils git libarchive-zip-perl libnet-ssleay-perl libhtml-parser-perl libxml-libxml-perl libjson-perl libjson-xs-perl libxml-libxslt-perl libjson-rpc-perl libarchive-zip-perl"

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -269,7 +269,7 @@ portdefault=1
 
 skip_rt=1
 sshport=''
-rudevflag=1
+rudevflag=0
 rurelease=master
 passfile='/etc/nginx/.htpasswd'
 package_list="sudo nano autoconf build-essential ca-certificates comerr-dev curl dtach htop irssi libcppunit-dev $libcver libncurses5-dev libterm-readline-gnu-perl libsigc++-2.0-dev libperl-dev libtool libxml2-dev ncurses-base ncurses-term ntp patch pkg-config $phpver-fpm $phpver $phpver-cli $phpver-dev $phpver-curl php-geoip $phpver-xmlrpc $phpver-xml python-scgi screen subversion texinfo unzip zlib1g-dev libcurl4-openssl-dev mediainfo software-properties-common aptitude $phpver-json nginx-full apache2-utils git libarchive-zip-perl libnet-ssleay-perl libhtml-parser-perl libxml-libxml-perl libjson-perl libjson-xs-perl libxml-libxslt-perl libjson-rpc-perl libarchive-zip-perl"

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -238,7 +238,7 @@ if [ "$relno" = "10" ] || [ "$(lsb_release -sr)" = "19.10" ]; then
 fi
 
 serveripa=$(ip route get 8.8.8.8 | awk 'NR==1 {print $7}')
-serveripb=$(wget -qO- ipecho.net/plain)
+serveripb=$(wget -qO- --timeout=3 ipecho.net/plain)
 
 if [ "$serveripa" = "$serveripb" ]; then
   serverip=$serveripa

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -558,7 +558,7 @@ for package_name in $package_list
 
 # Installs a package needed to prevent arm64 architectures from "WARNING: Unable to start rtorrent"
 if [ "$(uname --m)" == "aarch64" ] || [ "$(dpkg --print-architecture)" == "arm64" ] ; then
-    sudo apt-get install libxmlrpc-core-c3-dev
+    sudo apt-get install libxmlrpc-core-c3-dev -y
 fi
 
 test -z "$install_list" || apt-get -qq install $install_list >> $logfile 2>&1

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -182,7 +182,7 @@ echo $ip_address
 PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
 
 # if left blank will install latest version of rtorrent, or set to a specific release E.G. '0.9.6' to install that release
-rtorrentrel='0.9.6'
+rtorrentrel='0.9.8'
 
 #url's of the major components
 rt_url="http://rtorrent.net/downloads/"

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -15,7 +15,7 @@
 
 #function to check if a web site is reachable
 check_url() {
-  if [[ `wget -S --spider $1  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then return 0; else return 1; fi
+  if [[ `wget -S -T 3 --spider $1  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then return 0; else return 1; fi
 }
 
 # checks if an application is installed

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -521,13 +521,7 @@ echo
 if [[ $(systemctl list-units --all apt-daily.service | fgrep -c apt-daily.service) -gt 0 ]]; then
   systemctl stop apt-daily.service >> $logfile 2>&1
   systemctl kill --kill-who=all apt-daily.service >> $logfile 2>&1
-
-# wait until `apt-get updated` has been killed
-  while ! (systemctl list-units --all apt-daily.service | fgrep -q dead)
-    do
-      sleep 1;
-    done
-
+  sleep 5
 fi
 
 #update amd upgrade system

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -231,7 +231,7 @@ if [ "$relno" = "18" ] || [ "$relno" = "19" ]; then
   libcver=libcurl4
 fi
 
-if [ "$relno" = "10" ]; then
+if [ "$relno" = "10" ] || [ "$(lsb_release -sr)" = "19.10" ]; then
   phpver=php7.3
   phploc=/etc/php/7.3
   libcver=libcurl4

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -239,20 +239,23 @@ fi
 
 serveripa=$(ip route get 8.8.8.8 | awk 'NR==1 {print $7}')
 serveripb=$(wget -qO- --timeout=3 ipecho.net/plain)
+serveripc=$(wget -qO- --timeout=3 ipinfo.io/ip)
 
-if [ "$serveripa" = "$serveripb" ]; then
+if [ "$serveripa" = "$serveripb" ] || [ "$serveripa" = "$serveripc" ]; then
   serverip=$serveripa
 else
   echo "Select the IP address to use:"
   echo "1.) "$serveripa
   echo "2.) "$serveripb
+  echo "3.) "$serveripc
 
   while true
     do
       read answer
       case $answer in [1] ) serverip=$serveripa && break ;;
                       [2] ) serverip=$serveripb && break ;;
-                        * ) echo "Enter 1 or 2";;
+                      [3] ) serverip=$serveripc && break ;;
+                        * ) echo "Enter 1, 2 or 3";;
     esac
   done
 fi

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -909,7 +909,7 @@ adlpass=$(genpasswd $(random 12 16))
 
 mkdir -p $home/.irssi/scripts/autorun
 cd $home/.irssi/scripts
-curl -sL http://git.io/vlcND | grep -Po '(?<="browser_download_url": ")(.*-v[\d.]+.zip)' | xargs wget --quiet -O autodl-irssi.zip
+curl -sL http://git.io/vlcND | sed -n 's/.*browser_download_url": \?"\(.*zip\)".*/\1/p' | xargs wget --quiet -O autodl-irssi.zip
 unzip -qq -o autodl-irssi.zip | tee -a $logfile
 rm autodl-irssi.zip
 cp autodl-irssi.pl autorun/

--- a/scripts/rtinst
+++ b/scripts/rtinst
@@ -182,7 +182,7 @@ echo $ip_address
 PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
 
 # if left blank will install latest version of rtorrent, or set to a specific release E.G. '0.9.6' to install that release
-rtorrentrel='0.9.8'
+rtorrentrel='0.9.6'
 
 #url's of the major components
 rt_url="http://rtorrent.net/downloads/"

--- a/scripts/rtletsencrypt
+++ b/scripts/rtletsencrypt
@@ -65,7 +65,7 @@ if [ $(dpkg-query -W -f='${Status}' "certbot" 2>/dev/null | grep -c "ok installe
     deb_name=$(lsb_release --codename --short)
     grep "^deb http\:\/\/deb\.debian\.org\/debian $deb_name-backports main" /etc/apt/sources.list > /dev/null || echo "deb http://deb.debian.org/debian $deb_name-backports main" >> /etc/apt/sources.list
     apt-get -q update >> $logfile 2>&1
-    apt-get install -y certbot python-certbot-nginx -t stretch-backports >> $logfile 2>&1
+    apt-get install -y certbot python-certbot-nginx -t $deb_name-backports >> $logfile 2>&1
   fi
 else
   echo "certbot already installed"

--- a/scripts/rtupdate
+++ b/scripts/rtupdate
@@ -12,6 +12,7 @@ PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
 
 osname=$(lsb_release -si)
 relno=$(lsb_release -sr | cut -d. -f1)
+fullrelno=$(lsb_release -sr)
 
 # Fallback if lsb_release -si returns nothing
 if [ "$osname" = "" ]; then
@@ -21,8 +22,13 @@ fi
 
 # Fallback if lsb_release -sr returns nothing
 if [ "$relno" = "" ]; then
-  relno=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+  relno=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"' | cut -d. -f1)
 fi
+
+if [ "$fullrelno" = "" ]; then
+  fullrelno=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+fi
+
 
 sourcedir='http://rtorrent.net/downloads/'
 
@@ -34,7 +40,7 @@ xmlrpcloc_alt='https://github.com/mirror/xmlrpc-c/trunk/advanced'
 
 rtdevrel=1
 
-if [ "$relno" = "17.10" ]; then
+if [ "$fullrelno" = "17.10" ]; then
   rtdevrel=0
 fi
 

--- a/scripts/rtupdate
+++ b/scripts/rtupdate
@@ -75,7 +75,7 @@ hash $1 2>/dev/null
 
 #function to check if a web site is reachable
 check_url() {
-  if [[ `wget -S --spider $1  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then return 0; else return 1; fi
+  if [[ `wget -S -T 3 --spider $1  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then return 0; else return 1; fi
 }
 
 # function to create a list of versions to install

--- a/scripts/rtupdate
+++ b/scripts/rtupdate
@@ -12,6 +12,18 @@ PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/bin:/sbin
 
 osname=$(lsb_release -si)
 relno=$(lsb_release -sr | cut -d. -f1)
+
+# Fallback if lsb_release -si returns nothing
+if [ "$osname" = "" ]; then
+  osname=$(grep -oP '(?<=^ID=).+' /etc/os-release | tr -d '"')
+  osname=${osname^}
+fi
+
+# Fallback if lsb_release -sr returns nothing
+if [ "$relno" = "" ]; then
+  relno=$(grep -oP '(?<=^VERSION_ID=).+' /etc/os-release | tr -d '"')
+fi
+
 sourcedir='http://rtorrent.net/downloads/'
 
 xmlrpc_url='https://svn.code.sf.net/p/xmlrpc-c/code/advanced/'
@@ -22,7 +34,7 @@ xmlrpcloc_alt='https://github.com/mirror/xmlrpc-c/trunk/advanced'
 
 rtdevrel=1
 
-if [ $(lsb_release -sr) = 17.10 ]; then
+if [ "$relno" = "17.10" ]; then
   rtdevrel=0
 fi
 

--- a/scripts/rtupdate
+++ b/scripts/rtupdate
@@ -32,11 +32,11 @@ fi
 
 sourcedir='http://rtorrent.net/downloads/'
 
-xmlrpc_url='https://svn.code.sf.net/p/xmlrpc-c/code/advanced/'
-xmlrpcloc='svn://svn.code.sf.net/p/xmlrpc-c/code/advanced/'
+xmlrpc_url='https://svn.code.sf.net/p/xmlrpc-c/code/stable/'
+xmlrpcloc='svn://svn.code.sf.net/p/xmlrpc-c/code/stable/'
 
 xmlrpc_url_alt='https://github.com/mirror/xmlrpc-c'
-xmlrpcloc_alt='https://github.com/mirror/xmlrpc-c/trunk/advanced'
+xmlrpcloc_alt='https://github.com/mirror/xmlrpc-c/trunk/stable'
 
 rtdevrel=1
 


### PR DESCRIPTION
If ipecho is down or the ISP is blocking it, there are no other ways to get external ip. Adding another fallback to ipinfo.io makes the issue that rtinst can't figure out the external ip less likely.

Issue: #448